### PR TITLE
Update m4_spec.md and CHANGELOG.md for M4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unit test and whole app test with `playwright` (`#72`)
 - Interactive click has been implemented as the advanced feature. Users can click regions to deselect regions (`#77`)
 - Added a drop-down dashboard description in main page, and included the year of the data in the dashboard description. (`#68`,`#69`,`#77`)
+- DuckDB lazy loading via Ibis + Parquet, replacing eager pandas CSV loading (`#73`)
+- `convert_to_parquet.py` script to convert processed CSV to Parquet format (`#73`)
+- Updated demo gif to reflect M4 changes
 
 ### Changed
 - Dashboard theme (`#77`)
+- Data loading pipeline migrated from pandas CSV to Ibis + DuckDB backed by Parquet for lazy evaluation — all filtering now happens at the database level before data enters memory (`#73`)
 - World map out of school metrics has reversed color representation, so positive meanings are in yellow (out of school metrics when low, other metrics when high), and negative meanings are in blue (out of school metrics when high, other metrics when low) (`#70`).
 - Scatter plot data points display size has increased. (`#70`).
 - Bar plots have vertical dash lines to separate categories for easier read. (`#69`).

--- a/report/m4_spec.md
+++ b/report/m4_spec.md
@@ -101,14 +101,18 @@ Displays how many countries have available literacy data for the current filter.
 This dashboard implements **Option D** by treating chart outputs as interactive inputs.  
 Clickable dashboard outputs will be used as inputs for linked filtering.
 
-### To be implemented
-- Clicking a region in either bar chart updates the dashboard filter (i.e. remove regions by clicking those regions on either bar chart)
-- Clicking a point in the literacy scatterplot updates the dashboard filter (i.e. remove regions by clicking those regions on scatterplot)
-- The region checkbox input stays synchronized with chart interaction
-- The map, KPI cards, charts, and data table react to the selected region(s)
-- Reset clears all selected regions
+### M4 Architecture Decision: DuckDB Lazy Loading
+
+In M4, the data loading pipeline was migrated from eager pandas CSV loading to lazy evaluation using Ibis + DuckDB backed by a Parquet file. This decision was made before implementation to improve performance and memory efficiency. The processed CSV was converted to Parquet format (`convert_to_parquet.py`), and all filtering now happens at the database level via Ibis expressions before data enters a DataFrame.
+
+### Implemented (M4)
+- Clicking a region in the literacy scatterplot toggles the region filter and updates the entire dashboard
+- The region checkbox input stays synchronized with chart interactions
+- The map, KPI cards, charts, and data table all react to the selected region(s)
+- Reset clears all selected regions (deselects everything)
 - Empty-state messages appear when no region is selected
 - A literacy coverage note shows how many countries have valid data for the scatterplot
+- Data pipeline switched from pandas CSV to Ibis + DuckDB with Parquet for lazy loading
 
 ### Testing
 


### PR DESCRIPTION
- updated m4_spec.md — replaced "To be implemented" with actual M4 deliverables and added DuckDB lazy loading architecture decision
- updated CHANGELOG.md [0.4.0] — added DuckDB/Parquet migration, convert_to_parquet.py, and updated demo gif entries under Added/Changed